### PR TITLE
Fix line_decoder in HUB75_I2S_CFG and bump version to 3.0.15

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESP32 HUB75 LED MATRIX PANEL DMA Display",
-    "version": "3.0.14",
+    "version": "3.0.15",
     "description": "An Adafruit GFX compatible library for LED matrix modules which uses DMA for ultra-fast refresh rates and therefore very low CPU usage.",
     "keywords": "hub75, esp32, esp32s2, esp32s3, display, dma, rgb matrix",
     "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32 HUB75 LED MATRIX PANEL DMA Display
-version= 3.0.14
+version= 3.0.15
 author=MrCodetastic
 maintainer=MrCodetastic 
 sentence=HUB75 LED Matrix Library for ESP32, ESP32-S2 and ESP32-S3

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -332,7 +332,7 @@ struct HUB75_I2S_CFG
       bool _clockphase = true, 
       uint16_t _min_refresh_rate = 60, 
       uint8_t _pixel_color_depth_bits = PIXEL_COLOR_DEPTH_BITS_DEFAULT) 
-      : mx_width(_w), mx_height(_h), chain_length(_chain), gpio(_pinmap), driver(_drv), double_buff(_dbuff), i2sspeed(_i2sspeed), latch_blanking(_latblk), clkphase(_clockphase), min_refresh_rate(_min_refresh_rate)
+      : mx_width(_w), mx_height(_h), chain_length(_chain), gpio(_pinmap), driver(_drv), line_decoder(_line_drv), double_buff(_dbuff), i2sspeed(_i2sspeed), latch_blanking(_latblk), clkphase(_clockphase), min_refresh_rate(_min_refresh_rate)
   {
     setPixelColorDepthBits(_pixel_color_depth_bits);
   }


### PR DESCRIPTION
This pull request updates the version of the ESP32 HUB75 LED MATRIX PANEL DMA Display library and makes a minor improvement to the `HUB75_I2S_CFG` struct constructor. The main changes are version bumps in metadata files and a constructor initialization fix.

Version updates:

* Bumped the library version from `3.0.14` to `3.0.15` in both `library.json` and `library.properties` to reflect the latest changes. [[1]](diffhunk://#diff-64cc7cdde6789dc1c1c4a6f406cd1ff6a6a00027097788e2d52fc27b0d75502eL3-R3) [[2]](diffhunk://#diff-f267f9ae2f5d5d56a1dbb305e95d40d4408d9ee7f71357f1f67fb18c29b7f082L2-R2)

Code improvement:

* Updated the `HUB75_I2S_CFG` struct constructor in `ESP32-HUB75-MatrixPanel-I2S-DMA.h` to initialize the `line_decoder` member, ensuring all member variables are properly set during construction.